### PR TITLE
chore: ignore .DS_Store and prevent future commits

### DIFF
--- a/FoundationRelativity/.gitignore
+++ b/FoundationRelativity/.gitignore
@@ -1,0 +1,1 @@
+.DS_Store


### PR DESCRIPTION
## Summary
Adds `.DS_Store` to `.gitignore` so macOS metadata files are never committed.

## Changes
* Append `.DS_Store` entry to `.gitignore`

## Testing
* No code changed; CI should remain green.