### PR TITLE
feat(spectral-gap): PR #4 – first concrete SpectralGapOperator (with …

### DIFF
--- a/SpectralGap/HilbertSetup.lean
+++ b/SpectralGap/HilbertSetup.lean
@@ -14,11 +14,6 @@ import Mathlib.Analysis.InnerProductSpace.l2Space
 import Mathlib.Analysis.NormedSpace.OperatorNorm
 import Mathlib.Analysis.InnerProductSpace.Adjoint
 import Mathlib.Analysis.NormedSpace.CompactOperator
-import Mathlib.Analysis.NormedSpace.Spectrum
-import Mathlib.Analysis.InnerProductSpace.PiL2
-
-open Complex
-open scoped BigOperators
 
 namespace SpectralGap
 
@@ -35,25 +30,6 @@ abbrev IsCompact (T : BoundedOp) : Prop := IsCompactOperator T
 def IsSelfAdjoint (T : BoundedOp) : Prop :=
   ContinuousLinearMap.adjoint T = T
 
-/-- Rank-one projection onto the first basis vector e₀ -/
-noncomputable def proj₁ : BoundedOp :=
-  ContinuousLinearMap.mk {
-    toFun := fun f ↦ fun n ↦ if n = 0 then f 0 else 0,
-    map_add' := by
-      intro f g
-      funext n
-      by_cases h : n = 0 <;> simp [h],
-    map_smul' := by
-      intro c f  
-      funext n
-      by_cases h : n = 0 <;> simp [h]
-  } (by
-    -- The projection is bounded with norm ≤ 1
-    use 1
-    intro f
-    simp [proj₁]
-    sorry -- Proof that ||proj₁ f|| ≤ ||f|| for now
-  )
 
 /-- **Bundled object with a spectral gap**.
 
@@ -66,24 +42,7 @@ structure SpectralGapOperator where
   selfAdj : IsSelfAdjoint T
   a       : ℝ
   b       : ℝ
-  gap_lt  : a < b
-  gap     : ∀ z ∈ spectrum ℂ T, z.re ≤ a ∨ b ≤ z.re
-
-/-- First concrete SpectralGapOperator using rank-one projection -/
-noncomputable def projGapOp : SpectralGapOperator := {
-  T := proj₁,
-  compact := by
-    -- Finite-rank operators are compact
-    sorry, -- Will need to prove proj₁ is finite rank
-  selfAdj := by
-    -- Projection operators are self-adjoint  
-    sorry, -- Will need to prove proj₁.adjoint = proj₁
-  a := 0,
-  b := 1, 
-  gap_lt := by norm_num,
-  gap := by
-    -- Spectrum of projection is {0,1}, so gap holds
-    sorry -- Will need spectrum analysis
-}
+  gap_lt  : True        -- ← placeholder, will be `a < b`
+  gap     : True        -- ← placeholder, will be spectrum condition
 
 end SpectralGap

--- a/SpectralGap/HilbertSetup.lean
+++ b/SpectralGap/HilbertSetup.lean
@@ -14,6 +14,11 @@ import Mathlib.Analysis.InnerProductSpace.l2Space
 import Mathlib.Analysis.NormedSpace.OperatorNorm
 import Mathlib.Analysis.InnerProductSpace.Adjoint
 import Mathlib.Analysis.NormedSpace.CompactOperator
+import Mathlib.Analysis.NormedSpace.Spectrum
+import Mathlib.Analysis.InnerProductSpace.PiL2
+
+open Complex
+open scoped BigOperators
 
 namespace SpectralGap
 
@@ -30,6 +35,26 @@ abbrev IsCompact (T : BoundedOp) : Prop := IsCompactOperator T
 def IsSelfAdjoint (T : BoundedOp) : Prop :=
   ContinuousLinearMap.adjoint T = T
 
+/-- Rank-one projection onto the first basis vector e₀ -/
+noncomputable def proj₁ : BoundedOp :=
+  ContinuousLinearMap.mk {
+    toFun := fun f ↦ fun n ↦ if n = 0 then f 0 else 0,
+    map_add' := by
+      intro f g
+      funext n
+      by_cases h : n = 0 <;> simp [h],
+    map_smul' := by
+      intro c f  
+      funext n
+      by_cases h : n = 0 <;> simp [h]
+  } (by
+    -- The projection is bounded with norm ≤ 1
+    use 1
+    intro f
+    simp [proj₁]
+    sorry -- Proof that ||proj₁ f|| ≤ ||f|| for now
+  )
+
 /-- **Bundled object with a spectral gap**.
 
     *All* five fields already appear in the final API, so later work can
@@ -41,7 +66,24 @@ structure SpectralGapOperator where
   selfAdj : IsSelfAdjoint T
   a       : ℝ
   b       : ℝ
-  gap_lt  : True        -- ← was  `a < b`
-  gap     : True        -- placeholder for  `Spectrum ℂ T ⊆ ...`
+  gap_lt  : a < b
+  gap     : ∀ z ∈ spectrum ℂ T, z.re ≤ a ∨ b ≤ z.re
+
+/-- First concrete SpectralGapOperator using rank-one projection -/
+noncomputable def projGapOp : SpectralGapOperator := {
+  T := proj₁,
+  compact := by
+    -- Finite-rank operators are compact
+    sorry, -- Will need to prove proj₁ is finite rank
+  selfAdj := by
+    -- Projection operators are self-adjoint  
+    sorry, -- Will need to prove proj₁.adjoint = proj₁
+  a := 0,
+  b := 1, 
+  gap_lt := by norm_num,
+  gap := by
+    -- Spectrum of projection is {0,1}, so gap holds
+    sorry -- Will need spectrum analysis
+}
 
 end SpectralGap

--- a/test/SpectralGapProofTest.lean
+++ b/test/SpectralGapProofTest.lean
@@ -1,7 +1,10 @@
 import SpectralGap.Proofs
+import SpectralGap.HilbertSetup
 import Lean
 
 open IO
+open SpectralGap
 
-def main : IO Unit :=
+def main : IO Unit := do
   println "✓ Spectral‑Gap proof type‑checks"
+  println s!"✓ SpectralGapOperator example has gap: {projGapOp.gap_lt}"

--- a/test/SpectralGapProofTest.lean
+++ b/test/SpectralGapProofTest.lean
@@ -1,10 +1,7 @@
 import SpectralGap.Proofs
-import SpectralGap.HilbertSetup
 import Lean
 
 open IO
-open SpectralGap
 
-def main : IO Unit := do
+def main : IO Unit :=
   println "✓ Spectral‑Gap proof type‑checks"
-  println s!"✓ SpectralGapOperator example has gap: {projGapOp.gap_lt}"


### PR DESCRIPTION
## Summary
  - Reverts incomplete proj₁ definition that failed type checking in CI
  - Restores gap_lt and gap to True placeholders for stability
  - Removes heavy spectrum imports that caused slow builds
  - Maintains zero-sorry policy and fast CI (~30s with cache)

  ## Changes
  - Remove broken rank-one projection implementation
  - Restore `gap_lt: True` and `gap: True` stubs in SpectralGapOperator
  - Clean up imports (remove spectrum-related dependencies)
  - Revert test to basic compilation check

  ## Purpose
  This cleanup PR gets CI green again and sets up a stable foundation for Math-AI to
  implement the correct projection operator in a follow-up PR.

  ## Next Steps
  Math-AI will create `feat/sgap-projection` with proper:
  - `ContinuousLinearMap.rankOne` implementation
  - Zero-sorry proofs for compactness and self-adjointness
  - Real spectrum gap condition

  🤖 Generated with [Claude Code](https://claude.ai/code)