### PR TITLE
feat: implement Milestone C groundwork for SpectralGap impossibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- feat: Milestone C groundwork - RequiresACω logic DSL for SpectralGap impossibility proofs
 - feat: formal proof that RNP_Fail₂ requires DC_ω (ρ = 2)
 
 ## [0.3.2] - 2025-01-20

--- a/SpectralGap/LogicDSL.lean
+++ b/SpectralGap/LogicDSL.lean
@@ -1,0 +1,20 @@
+/-! # Weak Choice DSL for Milestone C
+
+`RequiresACω` is an internal proposition we'll use to re-express
+the constructive impossibility witness.
+-/
+namespace SpectralGap
+
+/-- "We need countable choice" – a dummy stand-in until the real
+   proof is finished in Milestone D. -/
+inductive RequiresACω : Prop
+| mk : RequiresACω    -- one trivial constructor
+
+attribute [simp] RequiresACω.mk
+
+/-- Convenience lemma: once we have `RequiresACω`, we can derive anything
+    that is classically provable with countable choice.  (Placeholder.) -/
+theorem requiresACω_imp {P : Prop} : RequiresACω → P → P := by
+  intro _ hP; exact hP
+
+end SpectralGap

--- a/SpectralGap/NoWitness.lean
+++ b/SpectralGap/NoWitness.lean
@@ -1,19 +1,15 @@
-import Found.LogicDSL
--- Additional imports will be added for ultrafilter constructions
+import SpectralGap.HilbertSetup
+import SpectralGap.LogicDSL
 
-/-!
-# Constructive Impossibility of Spectral Gap Witnesses
+open SpectralGap
 
-This module proves that spectral gap witnesses cannot be constructed in BISH.
+namespace SpectralGap
 
-Milestone C implementation - Bishop-style argument showing that an explicit 
-eigenvector in the gap would yield an ultrafilter, requiring AC_ω.
--/
+/-- If we merely *assume* `gap_lt` and `gap` but never exhibit
+    an eigenvector witnessing the gap, we need a form of countable choice. -/
+theorem zeroGap_requiresACω : RequiresACω := by
+  -- 🚧  You will give the real constructive proof here.
+  -- For now we close it with the constructor to keep CI green.
+  exact RequiresACω.mk
 
-/-!
-## Main Results
-
-- `noWitness_bish_detailed`: Constructive impossibility of spectral gap witnesses
-- Connection to WLPO-style template from Found.LogicDSL  
-- Ultrafilter construction requiring AC_ω
--/
+end SpectralGap

--- a/test/SpectralGapProofTest.lean
+++ b/test/SpectralGapProofTest.lean
@@ -1,9 +1,10 @@
-import SpectralGap.Proofs
-import SpectralGap.HilbertSetup
+import SpectralGap.NoWitness
 import Lean
 
 open IO SpectralGap
 
 def main : IO Unit := do
-  println "✓ Spectral‑Gap proof type‑checks"
-  println "✓ zeroGapOp concrete operator created with real spectrum gap proof"
+  println "✓ Spectral-Gap proof type-checks"
+  println s!"✓ zeroGapOp exists: {SpectralGap.zeroGapOp.gap_lt}"
+  -- Milestone C confirmation
+  println "✓ Constructive impossibility lemma compiled (RequiresACω)."


### PR DESCRIPTION
## Summary

Implements Math-AI's Milestone C skeleton for constructive impossibility proofs.

### Changes Made

✅ **C-1**: Created `SpectralGap/LogicDSL.lean` with `RequiresACω` proposition
✅ **C-2**: Updated `SpectralGap/NoWitness.lean` with `zeroGap_requiresACω` theorem
✅ **C-3**: Updated test to confirm Milestone C compilation
✅ **Documentation**: Added Milestone C to CHANGELOG.md under Unreleased

### Implementation Details

- **RequiresACω**: Placeholder proposition representing need for countable choice
- **zeroGap_requiresACω**: Theorem stating spectral gap requires AC_ω (placeholder proof)
- **Test confirmation**: Added "Constructive impossibility lemma compiled" message

### Technical Notes

- All proofs are currently trivial placeholders to keep CI green
- Real constructive proofs will be added in Milestone D
- No new axioms introduced (check-no-axioms.sh will pass)
- TD-B-001 (spectrum proof) remains untouched as requested

### Next Steps

- Implement real constructive impossibility proof in Milestone D
- Consider mathlib 4.4 upgrade spike for TD-B-001 resolution
- Add more sophisticated logic DSL as needed

This sets the foundation for proving that explicit spectral gap witnesses require non-constructive choice principles.

🤖 Generated with [Claude Code](https://claude.ai/code)