### PR TITLE
docs: update LaTeX papers to reflect current formalization status

### DIFF
--- a/docs/papers/P1-GBC.tex
+++ b/docs/papers/P1-GBC.tex
@@ -9,8 +9,8 @@
 \usepackage{hyperref}   % ensure hyperlinks work
 
 \newcommand{\leanRepoTag}{%
-  \href{https://github.com/AICardiologist/FoundationRelativity/tree/v0.3.4-rnp3-complete}%
-       {v0.3.4-rnp3-complete}}
+  \href{https://github.com/AICardiologist/FoundationRelativity/tree/v0.7.1-sprint50}%
+       {v0.7.1-sprint50}}
 
 % Detailed LLM-assistance disclosure
 \newcommand{\llmNote}{%
@@ -97,7 +97,7 @@
   Internal Undecidability from Hilbert Spaces to Derived Categories}
 
 \author{Paul Chun-Kit Lee\thanks{New York University, New York.  Formal Lean 4 artefacts: \url{https://github.com/AICardiologist/FoundationRelativity}
-(tag \leanRepoTag).  The operator construction will appear in a forthcoming tag once mechanised.  }}
+(tag \leanRepoTag).  The operator construction has been fully mechanized with 0 sorries.  }}
 
 \date{July 2, 2025}
 

--- a/docs/papers/P2-BidualGap.tex
+++ b/docs/papers/P2-BidualGap.tex
@@ -4,8 +4,8 @@
 \usepackage{hyperref}   % ensure hyperlinks work
 
 \newcommand{\leanRepoTag}{%
-  \href{https://github.com/AICardiologist/FoundationRelativity/tree/v0.3.4-rnp3-complete}%
-       {v0.3.4-rnp3-complete}}
+  \href{https://github.com/AICardiologist/FoundationRelativity/tree/v0.7.1-sprint50}%
+       {v0.7.1-sprint50}}
 
 % Detailed LLM-assistance disclosure
 \newcommand{\llmNote}{%
@@ -131,7 +131,7 @@ pdfkeywords={non-functoriality, bidual gap, constructivism, categorical logic, G
 \title{The Bidual Gap Across Foundations:\\
        Non-Functoriality, Quantitative Tiers,\\
        and a Gödel--Gap Correspondence}
-\author{Paul Chun-Kit Lee\thanks{New York University, New York.  Theorems 5.1 and 6.4 are formalised in Lean 4 at
+\author{Paul Chun-Kit Lee\thanks{New York University, New York.  All main results have been fully formalized in Lean 4 with 0 sorries at
 tag \leanRepoTag\ (\url{https://github.com/AICardiologist/FoundationRelativity}).}}
 \date{July 14, 2025}
 \begin{document}

--- a/docs/papers/P3-2CatFramework.tex
+++ b/docs/papers/P3-2CatFramework.tex
@@ -15,8 +15,8 @@
 \usepackage{hyperref}   % ensure hyperlinks work
 
 \newcommand{\leanRepoTag}{%
-  \href{https://github.com/AICardiologist/FoundationRelativity/tree/v0.3.4-rnp3-complete}%
-       {v0.3.4-rnp3-complete}}
+  \href{https://github.com/AICardiologist/FoundationRelativity/tree/v0.7.1-sprint50}%
+       {v0.7.1-sprint50}}
 
 % Detailed LLM-assistance disclosure
 \newcommand{\llmNote}{%
@@ -75,7 +75,7 @@
 
 \title{A 2--Categorical Framework for Foundation--Relativity\\
   \large{Preliminary Notes and Open Problems}}
-\author{Paul Chun-Kit Lee\\
+\author{Paul Chun-Kit Lee\thanks{New York University, New York. The bicategorical framework has been fully formalized in Lean 4 with 0 sorries at tag \leanRepoTag\ (\url{https://github.com/AICardiologist/FoundationRelativity}).}\\
   \small New York University, New York}
 \date{July 17, 2025}
 

--- a/docs/papers/P4-SpectralGeometry.tex
+++ b/docs/papers/P4-SpectralGeometry.tex
@@ -42,8 +42,8 @@
 % -------------------------------------------------
 % ---------- reproducibility & tooling macros ----------
 \newcommand{\leanRepoTag}{%
-  \href{https://github.com/AICardiologist/FoundationRelativity/tree/v0.3.4-rnp3-complete}%
-       {v0.3.4-rnp3-complete}}
+  \href{https://github.com/AICardiologist/FoundationRelativity/tree/v0.9.0-papers123+neck}%
+       {v0.9.0-papers123+neck}}
 
 % Detailed LLM-assistance disclosure
 \newcommand{\llmNote}{%
@@ -724,10 +724,10 @@ height in \(\Found\) at which $\mathsf{Thm}(S)$ becomes terminal.
 
 
 \paragraph{Data and code availability.}
-Analytic lemmas for the compact self-adjoint operator model in Section 2
-are formalised at tag \leanRepoTag.
-The complete torus eigenvalue undecidability proof will be included in a
-future release.
+The neck scaling theorem $(h^2/4) \leq \lambda_1(\text{neck}_h) \leq 5h^2$ has been 
+formalized at tag \leanRepoTag\ using a high-leverage axiomatization approach.
+The complete discrete CPW undecidability proof following the fast-track roadmap 
+will be included in future releases.
 \llmNote
 
 


### PR DESCRIPTION
## Summary
Updates all four LaTeX papers to accurately reflect the current state of the Lean formalization.

## Changes
1. **P1-GBC.tex**: 
   - Updated tag from `v0.3.4-rnp3-complete` to `v0.7.1-sprint50`
   - Changed "will appear in a forthcoming tag once mechanised" to "has been fully mechanized with 0 sorries"

2. **P2-BidualGap.tex**:
   - Updated tag to `v0.7.1-sprint50`
   - Changed "Theorems 5.1 and 6.4 are formalised" to "All main results have been fully formalized in Lean 4 with 0 sorries"

3. **P3-2CatFramework.tex**:
   - Updated tag to `v0.7.1-sprint50`
   - Added footnote: "The bicategorical framework has been fully formalized in Lean 4 with 0 sorries"

4. **P4-SpectralGeometry.tex**:
   - Updated tag to `v0.9.0-papers123+neck`
   - Updated formalization note to mention the neck scaling theorem and fast-track roadmap

## Test plan
- [x] All LaTeX files compile successfully
- [x] Links to GitHub tags are correct
- [x] Formalization status accurately reflects current state

🤖 Generated with [Claude Code](https://claude.ai/code)