### PR TITLE
p2: remove deprecated WLPO stubs (allowlist trimmed)

### DIFF
--- a/Papers/P2_BidualGap/HB/DualIsometriesComplete.lean
+++ b/Papers/P2_BidualGap/HB/DualIsometriesComplete.lean
@@ -1555,21 +1555,6 @@ def SCNP (X : Type*) [NormedAddCommGroup X] : Prop :=
 section ConditionalWLPO
 variable [HasWLPO]
 
-/-- WLPO ⇒ SCNP(ℓ¹) (conditional, assumes `[HasWLPO]`).
-    Use WLPO to uniformly control tails of `∑ |u_n i - x i|` and combine with finite-coordinate control. -/
-@[deprecated "Not used in main proof path - see dual_is_banach_c0_from_WLPO_underWLPO"]
-theorem WLPO_implies_SCNP_l1_underWLPO :
-  SCNP (lp (fun _ : ι => ℝ) 1) := by
-  -- TODO: Use `HasWLPO.em_all_false` where WLPO is needed
-  sorry
-
-/-- From SCNP to completeness (conditional, assumes `[HasWLPO]`). -/
-@[deprecated "Not used in main proof path - see dual_is_banach_c0_from_WLPO_underWLPO"]
-theorem SCNP_implies_complete_underWLPO {X} [NormedAddCommGroup X] [NormedSpace ℝ X] :
-  SCNP X → CompleteSpace X := by
-  -- TODO: Standard sequence argument
-  sorry
-
 /-- Under WLPO, transport completeness from `ℓ¹` to `(c₀)^*` via the dual isometry (conditional). 
     Now uses inferInstance for CompleteSpace (lp _ 1) directly. -/
 theorem dual_is_banach_c0_from_WLPO_underWLPO :
@@ -1590,21 +1575,6 @@ end ConditionalWLPO
 
 noncomputable section ClassicalCorollaries
 open Classical
-
-/-- Classical corollary: WLPO ⇒ SCNP(ℓ¹).
-    No `[HasWLPO]` required in the signature: the instance is provided here. -/
-@[deprecated "Not used in main proof path - see dual_is_banach_c0_from_WLPO"]
-theorem WLPO_implies_SCNP_l1 :
-  SCNP (lp (fun _ : ι => ℝ) 1) := by
-  haveI : HasWLPO := instHasWLPO_of_Classical
-  exact WLPO_implies_SCNP_l1_underWLPO
-
-/-- Classical corollary: From SCNP to completeness. -/
-@[deprecated "Not used in main proof path - see dual_is_banach_c0_from_WLPO"]
-theorem SCNP_implies_complete {X} [NormedAddCommGroup X] [NormedSpace ℝ X] :
-  SCNP X → CompleteSpace X := by
-  haveI : HasWLPO := instHasWLPO_of_Classical
-  exact SCNP_implies_complete_underWLPO
 
 /-- Classical corollary: Under WLPO, transport completeness from `ℓ¹` to `(c₀)^*` via the dual isometry. -/
 theorem dual_is_banach_c0_from_WLPO :

--- a/SORRY_ALLOWLIST.txt
+++ b/SORRY_ALLOWLIST.txt
@@ -272,9 +272,7 @@ Papers/P2_BidualGap/Constructive/CReal_obsolete/Completeness.lean:151  # CReal i
 
 # Paper 2 DualStructure (deprecated lemmas already counted above)
 
-# Paper 2 Sprint E: HB/DualIsometriesComplete (2 deprecated WLPO lemmas)
-Papers/P2_BidualGap/HB/DualIsometriesComplete.lean:1564         # WLPO_implies_SCNP_l1_underWLPO (deprecated)
-Papers/P2_BidualGap/HB/DualIsometriesComplete.lean:1571         # SCNP_implies_complete_underWLPO (deprecated)
+# Paper 2 Sprint E: HB/DualIsometriesComplete (deprecated lemmas removed)
 
 # Paper 2 HB/DualIsometries (complete list after refactoring)
 Papers/P2_BidualGap/HB/DualIsometries.lean:76                          # Skeleton


### PR DESCRIPTION
Stubs now unused after inferInstance+transport; removes two sorries from allowlist. No CI impact (P2_Minimal unchanged).