### PR TITLE
feat(P3B): PR-2A — parametric tags (26 → 24)

### DIFF
--- a/Papers/P3_2CatFramework/P4_Meta/ProofTheory/Collisions.lean
+++ b/Papers/P3_2CatFramework/P4_Meta/ProofTheory/Collisions.lean
@@ -39,9 +39,9 @@ namespace Ax
     2. Apply RFN_implies_Con to get ConsistencyFormula  
     3. Apply con_tag_equiv_sem inverse to get consFormula
 -/
-axiom collision_tag (T0 : Theory) (n : Nat) :
-  (LReflect T0 (n+1)).Provable (reflFormula n) →
-  (LReflect T0 (n+1)).Provable (consFormula n)
+axiom collision_tag (T0 : Theory) [HasArithmetization T0] (n : Nat) :
+  (LReflect T0 (n+1)).Provable (RfnTag[T0] n) →
+  (LReflect T0 (n+1)).Provable (ConTag[T0] n)
 
 /-- Semantic version of the collision: LReflect directly proves its own consistency.
     
@@ -66,7 +66,7 @@ axiom collision_step_semantic (T0 : Theory) (n : Nat)
     deep ordinal-theoretic relationships. Could potentially be derived from a 
     formalized ordinal analysis framework.
 -/
-axiom reflection_dominates_consistency_axiom (T0 : Theory) (n : Nat) (φ : Formula) :
+axiom reflection_dominates_consistency_axiom (T0 : Theory) [HasArithmetization T0] (n : Nat) (φ : Formula) :
   (LReflect T0 n).Provable φ → (LCons T0 (n + 1)).Provable φ
 
 /-- Reflection achieves consistency at the same height (modulo shift).
@@ -76,7 +76,7 @@ axiom reflection_dominates_consistency_axiom (T0 : Theory) (n : Nat) (φ : Formu
     **Note**: This is the converse direction - anything provable via consistency
     is achievable via reflection at the same or lower height.
 -/
-axiom reflection_height_dominance (T0 : Theory) (φ : Formula) (n : Nat) :
+axiom reflection_height_dominance (T0 : Theory) [HasArithmetization T0] (φ : Formula) (n : Nat) :
   (LCons T0 n).Provable φ → (LReflect T0 n).Provable φ ∨ ∃ m ≤ n, (LReflect T0 m).Provable φ
 
 end Ax
@@ -88,10 +88,10 @@ export Ax (collision_tag collision_step_semantic reflection_dominates_consistenc
 /-! ## Collision Theorems -/
 
 /-- The formal collision: R_{n+1} ⊢ Con(R_n) at the schematic level. -/
-theorem collision_step (T0 : Theory) (n : Nat) :
-  (LReflect T0 (n+1)).Provable (consFormula n) := by
+theorem collision_step (T0 : Theory) [HasArithmetization T0] (n : Nat) :
+  (LReflect T0 (n+1)).Provable (ConTag[T0] n) := by
   -- definitional: step n+1 adds the RFN tag at stage n
-  have hRFN : (LReflect T0 (n+1)).Provable (reflFormula n) :=
+  have hRFN : (LReflect T0 (n+1)).Provable (RfnTag[T0] n) :=
     LReflect_proves_RFN T0 n
   -- convert RFN-tag to Con-tag via the collision axiom
   exact collision_tag T0 n hRFN
@@ -107,8 +107,8 @@ def reflection_dominates_consistency (T0 : Theory) :
 , preserves := reflection_dominates_consistency_axiom T0 }
 
 /-- Special case: the collision at consistency formulas -/
-theorem reflection_proves_consistency (T0 : Theory) (n : Nat) :
-  (LReflect T0 (n+1)).Provable (consFormula n) :=
+theorem reflection_proves_consistency (T0 : Theory) [HasArithmetization T0] (n : Nat) :
+  (LReflect T0 (n+1)).Provable (ConTag[T0] n) :=
   collision_step T0 n
 
 /-! ## Height Comparison -/

--- a/Papers/P3_2CatFramework/P4_Meta/ProofTheory/Heights.lean
+++ b/Papers/P3_2CatFramework/P4_Meta/ProofTheory/Heights.lean
@@ -22,8 +22,8 @@ open Papers.P4Meta
 /-! ## Upper Bounds (Constructive) -/
 
 /-- Consistency has height 1 on the consistency ladder -/
-theorem con_height_upper (T0 : Theory) :
-  (LCons T0 1).Provable (consFormula 0) := by
+theorem con_height_upper (T0 : Theory) [HasArithmetization T0] :
+  (LCons T0 1).Provable (ConTag[T0] 0) := by
   simp [LCons, Extend_Proves]
 
 /-- Gödel sentence tag (schematic, not the actual Gödel sentence) -/
@@ -33,27 +33,27 @@ namespace Ax
 
 /-- Gödel sentence follows from consistency (classical).
     Provenance: Gödel 1931, via fixed-point construction. -/
-axiom con_implies_godel (T : Theory) (n : Nat) :
-  T.Provable (consFormula n) → T.Provable (godelFormula n)
+axiom con_implies_godel (T : Theory) [HasArithmetization T] (n : Nat) :
+  T.Provable (ConTag[T] n) → T.Provable (godelFormula n)
 
 end Ax
 
 export Ax (con_implies_godel)
 
 /-- Gödel sentence has height 1 on the consistency ladder -/
-theorem godel_height_upper (T0 : Theory) :
+theorem godel_height_upper (T0 : Theory) [HasArithmetization T0] :
   (LCons T0 1).Provable (godelFormula 0) := by
   apply con_implies_godel
   exact con_height_upper T0
 
 /-- RFN has height 1 on the reflection ladder -/
-theorem rfn_height_upper (T0 : Theory) :
-  (LReflect T0 1).Provable (reflFormula 0) := by
+theorem rfn_height_upper (T0 : Theory) [HasArithmetization T0] :
+  (LReflect T0 1).Provable (RfnTag[T0] 0) := by
   simp [LReflect, Extend_Proves]
 
 /-- Iterated consistency at height n -/
-theorem con_iter_height_upper (T0 : Theory) (n : Nat) :
-  (ExtendIter T0 consSteps (n+1)).Provable (consFormula n) := by
+theorem con_iter_height_upper (T0 : Theory) [HasArithmetization T0] (n : Nat) :
+  (ExtendIter T0 (consSteps T0) (n+1)).Provable (ConTag[T0] n) := by
   rw [← LCons_as_ExtendIter]
   apply LCons_proves_Con
 
@@ -132,22 +132,22 @@ export Ax (WLPO_lower LPO_lower)
 /-! ## Height Certificates -/
 
 /-- Certificate for consistency on LCons -/
-def con_height_cert (T0 : Theory) [Consistent T0] [HBL T0] :
-  HeightCertificate T0 consSteps (consFormula 0) :=
+def con_height_cert (T0 : Theory) [HasArithmetization T0] [Consistent T0] [HBL T0] :
+  HeightCertificate T0 (consSteps T0) (ConTag[T0] 0) :=
 { n := 1
 , upper := con_height_upper T0
 , note := "Upper: definitional; Lower: G2 (classical)" }
 
 /-- Certificate for Gödel sentence on LCons -/
-def godel_height_cert (T0 : Theory) [Consistent T0] [HBL T0] :
-  HeightCertificate T0 consSteps (godelFormula 0) :=
+def godel_height_cert (T0 : Theory) [HasArithmetization T0] [Consistent T0] [HBL T0] :
+  HeightCertificate T0 (consSteps T0) (godelFormula 0) :=
 { n := 1
 , upper := godel_height_upper T0
 , note := "Upper: via Con→G; Lower: G1 (classical)" }
 
 /-- Certificate for RFN on LReflect -/
-def rfn_height_cert (T0 : Theory) [Consistent T0] [HBL T0] :
-  HeightCertificate T0 reflSteps (reflFormula 0) :=
+def rfn_height_cert (T0 : Theory) [HasArithmetization T0] [Consistent T0] [HBL T0] :
+  HeightCertificate T0 (reflSteps T0) (RfnTag[T0] 0) :=
 { n := 1
 , upper := rfn_height_upper T0
 , note := "Upper: definitional; Lower: Feferman (classical)" }
@@ -170,8 +170,8 @@ def LPO_height_cert : HeightCertificate HA ClassicalitySteps LPO_formula :=
 /-! ## Iterated Heights -/
 
 /-- Height n consistency on the consistency ladder -/
-def con_n_height (T0 : Theory) [Consistent T0] [HBL T0] (n : Nat) :
-  HeightCertificate T0 consSteps (consFormula n) :=
+def con_n_height (T0 : Theory) [HasArithmetization T0] [Consistent T0] [HBL T0] (n : Nat) :
+  HeightCertificate T0 (consSteps T0) (ConTag[T0] n) :=
 { n := n + 1
 , upper := con_iter_height_upper T0 n
 , note := s!"Upper: iteration; Lower: G2^{n+1} (classical)" }

--- a/Papers/P3_2CatFramework/documentation/AXIOM_INDEX.md
+++ b/Papers/P3_2CatFramework/documentation/AXIOM_INDEX.md
@@ -1,21 +1,22 @@
 # Paper 3B Axiom Index
 
-> **⚠️ AXIOM BUDGET LOCKED AT 26**: Future PRs must not increase this count. CI will fail if axioms > 26.
+> **⚠️ AXIOM BUDGET LOCKED AT 24**: Future PRs must not increase this count. CI will fail if axioms > 24.
 
 This document tracks all axioms used in the Paper 3B proof-theoretic framework.
 All axioms are now in the `Ax` namespace for consistent naming and easy tracking.
 
 ## Summary Statistics
-- **Total Axioms**: 26 (17 Paper 3B specific + 9 base theory infrastructure)
-  - **Paper 3B Specific**: 17 axioms (BUDGET LOCKED - enforced by CI)
+- **Total Axioms**: 24 (15 Paper 3B specific + 9 base theory infrastructure)
+  - **Paper 3B Specific**: 15 axioms (BUDGET LOCKED - enforced by CI)
   - **Base Theory Infrastructure**: 9 axioms (HA, PA, EA, ISigma1, etc.)
 - **Namespace**: All axioms use `Ax.` prefix for consistency
-- **Discharge Plan**: 8 axioms are placeholders for future internalization
+- **Discharge Plan**: 6 axioms are placeholders for future internalization
 - **Permanent**: 18 axioms (9 Paper 3B classical + 9 base theory)
 
 ### Recent Progress
 - **PR-1**: ✅ Discharged `LCons_arithmetization_instance` and `LReflect_arithmetization_instance` - now derived from Core.ExtendIter_arithmetization
 - **PR-4**: ✅ Discharged `WLPO_height_upper` and `LPO_height_upper` - now proved via Extend_Proves
+- **PR-2A**: ✅ Discharged `cons_tag_refines` and `rfn_tag_refines` - tags now parametric and defeq to semantics
 
 ## Axioms by Category
 
@@ -25,11 +26,11 @@ All axioms are now in the `Ax` namespace for consistent naming and easy tracking
 ~~1. `Ax.LCons_arithmetization_instance` - Extension preserves arithmetization for LCons~~ DISCHARGED
 ~~2. `Ax.LReflect_arithmetization_instance` - Extension preserves arithmetization for LReflect~~ DISCHARGED
 
-### Schematic Tag Refinements (2 axioms)
-*Discharge plan: Connect tags to semantic formulas via arithmetization*
+### Schematic Tag Refinements (0 axioms - DISCHARGED ✅)
+*Successfully discharged in PR-2A by making tags parametric and defeq to semantic formulas*
 
-3. `Ax.cons_tag_refines` - Links ConTag(n) to ConsistencyFormula(LCons T0 n)
-4. `Ax.rfn_tag_refines` - Links RfnTag(n) to RFN_Sigma1_Formula(LReflect T0 n)
+~~3. `Ax.cons_tag_refines` - Links ConTag(n) to ConsistencyFormula(LCons T0 n)~~ DISCHARGED
+~~4. `Ax.rfn_tag_refines` - Links RfnTag(n) to RFN_Sigma1_Formula(LReflect T0 n)~~ DISCHARGED
 
 ### Collision Axioms (4 axioms)
 *Split into cross-ladder bridge and height comparison*


### PR DESCRIPTION
## Summary

This PR implements parametric tags to discharge the tag-semantics bridge axioms, reducing the axiom count from 26 to 24.

## What

Make `ConTag` and `RfnTag` theory-indexed and definitionally equal to `ConsistencyFormula (LCons T0 n)` and `RFN_Sigma1_Formula (LReflect T0 n)`.

## Why

Eliminates the two tag-semantics bridge axioms by design, mirroring the successful WLPO/LPO alignment strategy from PR #133.

## Implementation

### Key Changes
- **Mutual definitions**: Ladders and tags defined together to handle circular dependencies
- **Defeq by construction**: Tags are now abbreviations for semantic formulas
- **Scoped notation**: `ConTag[T0] n` and `RfnTag[T0] n` for readability
- **Trivial instances**: `RealizesCons` and `RealizesRFN` now have simple proofs

### Files Modified
- `Progressions.lean`: Parametric tags, removed bridge axioms
- `Collisions.lean`: Updated signatures to use parametric tags  
- `Heights.lean`: Added `HasArithmetization` constraints
- `AXIOM_INDEX.md`: Budget reduced from 26 to 24

## Impact

- **Axiom budget**: 26 → 24 ✅
- **No sorries**: Clean implementation
- **Stable interfaces**: Tag call-sites now pass `T0` parameter
- **CI passing**: All checks green

## Testing

```bash
./.ci/check_axioms.sh
# Output: Current axiom count: 24
# Output: ✅ Axiom budget check passed (24 ≤ 24)
```

## Context

Part of the Paper 3B axiom discharge effort:
- PR #130: Arithmetization propagation (28 → 26)
- PR #133: WLPO/LPO upper bounds (28 → 26 concurrent)
- **This PR**: Tag-semantics bridge (26 → 24)
- Next: PR-5 Core definability (target 24 → 22-23)

🤖 Generated with [Claude Code](https://claude.ai/code)