### PR TITLE
fix(P1): Update deprecated RCLike import to fix CI warnings

### DIFF
--- a/Papers/P1_GBC/RankOneToggle/Spectrum.lean
+++ b/Papers/P1_GBC/RankOneToggle/Spectrum.lean
@@ -2,7 +2,7 @@ import Papers.P1_GBC.RankOneToggle.Toggle
 
 import Mathlib.Analysis.InnerProductSpace.Basic
 import Mathlib.Analysis.Normed.Operator.ContinuousLinearMap
-import Mathlib.Analysis.NormedSpace.RCLike
+import Mathlib.Analysis.Normed.Module.RCLike.Basic
 -- We comment out the spectrum import as the required infrastructure is missing.
 -- import Mathlib.Analysis.Normed.Algebra.Spectrum
 


### PR DESCRIPTION
## Summary
Fixes the CI (Full) failure by updating a deprecated import in Paper 1.

## Problem
The ci-strict job was failing because it detected a deprecation warning in Papers/P1_GBC/RankOneToggle/Spectrum.lean:
```
warning: 'Mathlib.Analysis.NormedSpace.RCLike' has been deprecated
```

## Solution
Replace the deprecated import with the recommended one:
- Old: `import Mathlib.Analysis.NormedSpace.RCLike`
- New: `import Mathlib.Analysis.Normed.Module.RCLike.Basic`

## Testing
- Built Papers.P1_GBC.RankOneToggle.Spectrum without deprecation warnings
- Only 'sorry' warnings remain, which are allowed

This should fix the CI (Full) failures on main branch.

🤖 Generated with [Claude Code](https://claude.ai/code)