### PR TITLE
fix(P3): Remove unused variable and simp warnings to fix CI

### DIFF
--- a/Papers/P3_2CatFramework/Phase2_API.lean
+++ b/Papers/P3_2CatFramework/Phase2_API.lean
@@ -61,9 +61,9 @@ Uses classical logic for decidability. The if-chain is a placeholder
 for a proper lattice of levels to be developed in future phases.
 -/
 noncomputable def HeightAt (WF : WitnessFamily) : Option Level :=
-  if h₀ : Nonempty (UniformizableOn W_ge0 WF) then
+  if Nonempty (UniformizableOn W_ge0 WF) then
     some Level.zero
-  else if h₁ : Nonempty (UniformizableOn W_ge1 WF) then
+  else if Nonempty (UniformizableOn W_ge1 WF) then
     some Level.one
   else
     none

--- a/Papers/P3_2CatFramework/Phase2_Positive.lean
+++ b/Papers/P3_2CatFramework/Phase2_Positive.lean
@@ -29,8 +29,8 @@ open Papers.P3.Phase2API
 
 /-- Positive uniformization = uniformization + fiber non-emptiness. -/
 def PosUniformizableOn (W : Phase2.Foundation → Prop) (WF : WitnessFamily) : Prop :=
-  ∃ (U : UniformizableOn W WF),
-    ∀ {F} (hF : W F) (X : Sigma0), Nonempty (WF.C F X)
+  ∃ (_ : UniformizableOn W WF),
+    ∀ {F} (_ : W F) (X : Sigma0), Nonempty (WF.C F X)
 
 @[simp] theorem PosUniformizableOn.uniformizable {W WF} :
   PosUniformizableOn W WF → Nonempty (UniformizableOn W WF) :=

--- a/Papers/P3_2CatFramework/Phase2_PositiveTruthAlgebra.lean
+++ b/Papers/P3_2CatFramework/Phase2_PositiveTruthAlgebra.lean
@@ -32,7 +32,7 @@ lemma posUL_truth_iff
   {W : Phase2.Foundation → Prop}
   {B : Phase2.Foundation → Sigma0 → Bool} :
   PosUniformizableOn W (TruthFamily B)
-    ↔ (∀ {F} (hF : W F) (X : Sigma0), B F X = true) := by
+    ↔ (∀ {F} (_ : W F) (X : Sigma0), B F X = true) := by
   constructor
   · -- → : extract `true` everywhere from the non-emptiness component
     intro h; rcases h with ⟨_, ne⟩
@@ -54,12 +54,11 @@ lemma posUL_truth_iff
         η_id := by
           intro F hF X
           -- Everything reduces to `Equiv.refl PUnit`
-          simp [toUnit, TruthFamily_C, Truth_true, hAll hF X]
+          simp only [toUnit, TruthFamily_C, Truth_true]
         η_comp := by
           intro F G H φ ψ hF hG hH X
           -- Again, everything is `Equiv.refl PUnit` after rewriting
-          simp [toUnit, TruthFamily_C, Truth_true,
-                hAll hF X, hAll hG X, hAll hH X]
+          simp only [toUnit, TruthFamily_C, Truth_true]
           rfl },
       ?_⟩
     -- Non-emptiness of fibers: `Truth true` is inhabited

--- a/Papers/P3_2CatFramework/Phase3_Positive.lean
+++ b/Papers/P3_2CatFramework/Phase3_Positive.lean
@@ -18,8 +18,8 @@ open Papers.P3.Phase2API
 
 /-- Positive uniformization at numeric level k. -/
 def PosUniformizableOnN (k : Nat) (WF : WitnessFamily) : Prop :=
-  ∃ (U : UniformizableOnN k WF),
-    ∀ {F} (hF : W_ge k F) (X : Sigma0), Nonempty (WF.C F X)
+  ∃ (_ : UniformizableOnN k WF),
+    ∀ {F} (_ : W_ge k F) (X : Sigma0), Nonempty (WF.C F X)
 
 /-- Positive numeric height (0/1 implemented for now). -/
 noncomputable def PosHeightAtNat (WF : WitnessFamily) : Option Nat := by


### PR DESCRIPTION
## Summary
Fixes the remaining CI (Full) failures by removing all warnings from Paper 3 modules.

## Problem
After fixing Paper 1 import warnings, ci-strict was still failing due to warnings in Paper 3:
- Unused variable warnings in Phase2_API, Phase2_Positive, Phase3_Positive
- Unused simp arguments in Phase2_PositiveTruthAlgebra

## Solution
- Replace named variables with anonymous ones using underscore (_) where they're not used
- Use `simp only` instead of `simp` to avoid unused argument warnings

## Testing  
- All affected modules build without warnings
- Pre-commit checks pass
- No 'sorry' warnings are affected (those are allowed)

This should finally fix the CI (Full) workflow failures.

🤖 Generated with [Claude Code](https://claude.ai/code)