### PR TITLE
ci: Implement diff-based strict checking for sustainable CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -130,8 +130,12 @@ jobs:
   # Sprint 43 P2: CI Tightening with strict warnings/axiom gates
   ci-strict:
     runs-on: ubuntu-latest
+    # Only run on PRs; skip on main branch pushes
+    if: github.event_name == 'pull_request'
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0  # Need full history for diff
 
       - name: Set up Lean
         uses: leanprover/lean-action@v1
@@ -147,18 +151,43 @@ jobs:
             .lake/build
           key: ${{ runner.os }}-lake-strict-${{ hashFiles('lakefile.lean') }}
 
-      - name: Build with strict warnings
+      - name: Check warnings in changed files only
         run: |
-          echo "Building with strict linter flags..."
-          # Enable strict warnings for new modules (Papers/, CategoryTheory/)
+          echo "Checking for warnings in changed files..."
+          
+          # Get the base branch
+          BASE_BRANCH="origin/${{ github.base_ref }}"
+          
+          # Get list of changed Lean files
+          CHANGED_FILES=$(git diff --name-only "$BASE_BRANCH"...HEAD | grep -E '^(Papers/|CategoryTheory/).*\.lean$' || true)
+          
+          if [ -z "$CHANGED_FILES" ]; then
+            echo "✅ No Lean files changed in Papers/ or CategoryTheory/"
+            exit 0
+          fi
+          
+          echo "Changed files to check:"
+          echo "$CHANGED_FILES" | sed 's/^/  - /'
+          
+          # Build and check for warnings in changed files only
           lake build 2>&1 | tee build.log
           
-          # Check for warnings in new modules only (allow legacy warnings)
-          if grep -E "warning.*\/(Papers|CategoryTheory)\/" build.log | grep -v "declaration uses 'sorry'"; then
-            echo "❌ Warnings found in new modules - CI strict mode requires warning-free code"
+          # Extract warnings for changed files
+          WARNINGS=""
+          for file in $CHANGED_FILES; do
+            FILE_WARNINGS=$(grep -E "warning:.*$file" build.log | grep -v "declaration uses 'sorry'" || true)
+            if [ -n "$FILE_WARNINGS" ]; then
+              WARNINGS="${WARNINGS}${FILE_WARNINGS}\n"
+            fi
+          done
+          
+          if [ -n "$WARNINGS" ]; then
+            echo "❌ Warnings found in changed files:"
+            echo -e "$WARNINGS"
             exit 1
           fi
-          echo "✅ New modules are warning-free"
+          
+          echo "✅ Changed files are warning-free"
 
       - name: Documentation coverage check
         id: doc_coverage

--- a/.github/workflows/weekly-full-strict.yml
+++ b/.github/workflows/weekly-full-strict.yml
@@ -1,0 +1,77 @@
+name: Weekly Full Strict Check
+
+on:
+  schedule:
+    # Run at 3 AM UTC every Sunday
+    - cron: '0 3 * * 0'
+  workflow_dispatch:  # Allow manual trigger
+
+jobs:
+  full-strict-scan:
+    runs-on: ubuntu-latest
+    continue-on-error: true  # Non-blocking
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Lean
+        uses: leanprover/lean-action@v1
+        with:
+          use-mathlib-cache: true
+          build-args: "-K 400000"
+
+      - name: Full repository warning scan
+        run: |
+          echo "# Full Repository Warning Report" > warning_report.md
+          echo "Date: $(date -u '+%Y-%m-%d %H:%M UTC')" >> warning_report.md
+          echo "" >> warning_report.md
+          
+          # Build and collect all warnings
+          lake build 2>&1 | tee build.log || true
+          
+          # Count warnings by directory
+          echo "## Warning Summary by Directory" >> warning_report.md
+          echo "" >> warning_report.md
+          
+          for dir in Papers CategoryTheory; do
+            if [ -d "$dir" ]; then
+              COUNT=$(grep -c "warning:.*/$dir/" build.log 2>/dev/null || echo "0")
+              echo "- **$dir/**: $COUNT warnings" >> warning_report.md
+            fi
+          done
+          
+          echo "" >> warning_report.md
+          
+          # Detailed breakdown (excluding 'sorry' warnings)
+          echo "## Non-sorry Warnings" >> warning_report.md
+          echo "" >> warning_report.md
+          
+          WARNINGS=$(grep -E "warning:.*\/(Papers|CategoryTheory)\/" build.log | grep -v "declaration uses 'sorry'" || true)
+          
+          if [ -n "$WARNINGS" ]; then
+            echo '```' >> warning_report.md
+            echo "$WARNINGS" | head -50 >> warning_report.md
+            echo '```' >> warning_report.md
+            
+            TOTAL=$(echo "$WARNINGS" | wc -l)
+            echo "" >> warning_report.md
+            echo "Total non-sorry warnings: $TOTAL" >> warning_report.md
+          else
+            echo "🎉 No non-sorry warnings found!" >> warning_report.md
+          fi
+          
+          # Upload report as artifact
+          cat warning_report.md
+
+      - name: Upload warning report
+        uses: actions/upload-artifact@v4
+        with:
+          name: warning-report
+          path: warning_report.md
+          retention-days: 30
+
+      - name: Create issue if warning count increased
+        if: github.event_name == 'schedule'
+        run: |
+          # This is a placeholder for tracking warning trends
+          # In practice, you'd compare against a baseline
+          echo "::notice::Weekly warning scan complete. Check artifacts for full report."

--- a/scripts/check_diff_warnings.sh
+++ b/scripts/check_diff_warnings.sh
@@ -1,0 +1,60 @@
+#!/bin/bash
+# check_diff_warnings.sh - Check for warnings only in changed files
+# For Lean 4 projects using lake build
+
+set -euo pipefail
+
+# Colors for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m' # No Color
+
+# Get the base branch (usually main)
+BASE_REF="${1:-origin/main}"
+
+echo "Checking for warnings in files changed since $BASE_REF..."
+
+# Get list of changed Lean files in Papers/ and CategoryTheory/
+CHANGED_FILES=$(git diff --name-only "$BASE_REF"...HEAD | grep -E '^(Papers/|CategoryTheory/).*\.lean$' || true)
+
+if [ -z "$CHANGED_FILES" ]; then
+    echo -e "${GREEN}✓ No Lean files changed in Papers/ or CategoryTheory/${NC}"
+    exit 0
+fi
+
+echo "Changed files to check:"
+echo "$CHANGED_FILES" | sed 's/^/  - /'
+echo
+
+# Build and collect warnings
+echo "Building and checking for warnings..."
+lake build 2>&1 | tee build_output.log
+
+# Extract warnings for changed files only
+WARNINGS=""
+for file in $CHANGED_FILES; do
+    # Look for warnings mentioning this file (excluding 'sorry' warnings)
+    FILE_WARNINGS=$(grep -E "warning:.*$file" build_output.log | grep -v "declaration uses 'sorry'" || true)
+    if [ -n "$FILE_WARNINGS" ]; then
+        WARNINGS="${WARNINGS}${FILE_WARNINGS}\n"
+    fi
+done
+
+# Clean up
+rm -f build_output.log
+
+# Report results
+if [ -n "$WARNINGS" ]; then
+    echo -e "${RED}✗ Warnings found in changed files:${NC}"
+    echo -e "$WARNINGS"
+    echo
+    echo -e "${YELLOW}Please fix these warnings before merging.${NC}"
+    echo "Tip: To suppress specific linters, use:"
+    echo "  set_option linter.unusedVariables false"
+    echo "  set_option linter.unusedSimpArgs false"
+    exit 1
+else
+    echo -e "${GREEN}✓ No warnings in changed files!${NC}"
+    exit 0
+fi


### PR DESCRIPTION
## Summary
Resolves the perpetual CI (Full) failures on main by implementing a more sustainable 'no new warnings' approach.

## Problem
- CI (Full) perpetually fails on main due to warnings in legacy code
- This trains developers to ignore CI failures (dangerous)
- Fixing all legacy warnings is time-consuming with low ROI

## Solution
Implements the recommended diff-based strictness pattern:

### 1. PR-only strict checking
- `ci-strict` now only runs on PRs, not on main branch pushes
- Uses `if: github.event_name == 'pull_request'`

### 2. Diff-based scope
- Only checks warnings in files changed in the PR
- Compares against base branch to identify changed files
- Legacy warnings don't block new development

### 3. Weekly full scan (non-blocking)
- New `weekly-full-strict.yml` workflow
- Runs every Sunday at 3 AM UTC
- `continue-on-error: true` - doesn't fail CI
- Generates warning report as artifact for tracking debt

### 4. Helper script
- `scripts/check_diff_warnings.sh` for local testing
- Developers can run this before pushing to catch warnings early

## Benefits
✅ Green CI on main (nightly + core tests pass)
✅ New code stays warning-free (enforced on PRs)
✅ Legacy debt visible but not blocking
✅ Progressive improvement without disruption

## Testing
The new ci-strict job will run on this PR itself, demonstrating the diff-based approach.

## References
Based on CI best practices for managing technical debt:
- Signal over noise (focus on changed code)
- Progressive improvement (no new debt)
- Visibility without blocking (scheduled reports)

🤖 Generated with [Claude Code](https://claude.ai/code)