### PR TITLE
docs(P5): Clarify schematic nature of Schwarzschild scaffold

### DIFF
--- a/Papers/P5_GeneralRelativity/Paper5_GR_AxCal.tex
+++ b/Papers/P5_GeneralRelativity/Paper5_GR_AxCal.tex
@@ -224,7 +224,7 @@ Global hyperbolicity yields compact diamond sets; equicontinuity gives Ascoli--A
 \paragraph{Deep dive anchors (Height 0 demonstrations).}
 \begin{itemize}
 \item \textbf{D1 (EPS Core).} We implement the EPS kinematics framework showing how light rays and free fall determine metric structure. The implementation provides a Height~0 certificate by avoiding all portals, demonstrating that the EPS reconstruction can be done constructively. The current version provides the structural scaffold; future work could expand the symbolic computation.
-\item \textbf{D2 (Schwarzschild Engine).} We provide a minimal tensor computation framework for verifying vacuum solutions. The implementation shows how Christoffel symbols, Ricci tensor, and Einstein tensor can be computed symbolically at Height~0, avoiding choice, compactness, and logic portals. The framework is ready for concrete symbolic expansion.
+\item \textbf{D2 (Schwarzschild Engine).} We provide a typed, schematic scaffold for Schwarzschild (coordinates, nonzero slots, proof pipeline). Current proof obligations are represented by \texttt{True} placeholders (no \texttt{sorry}); the symbolic derivations $G_{\mu\nu}=0$ are deferred to v1.1. The framework demonstrates Height~0 structure while concrete component formulas await implementation.
 \end{itemize}
 
 \begin{mdframed}[style=status]

--- a/Papers/P5_GeneralRelativity/README.md
+++ b/Papers/P5_GeneralRelativity/README.md
@@ -144,9 +144,15 @@ lake build Papers.P5_GeneralRelativity.Tests.TruthTable
 
 ### Verification Status
 - **No-sorry requirement**: ✅ **COMPLETE** - Zero sorries in entire Paper 5 codebase
+  - *Note*: "No-sorry" means all proofs present are closed in Lean; it does not imply that every deep computation has been carried out. For Schwarzschild we currently ship a typed scaffold with `True` placeholders; the full component computations land in v1.1.
 - **Certificate completeness**: ✅ All G1-G5 targets have HeightCertificate instances
 - **Portal soundness**: ✅ All route flags trigger appropriate axiom tokens
 - **CI/CD Pipeline**: ✅ Automated builds, PDF generation, and axiom auditing
+
+## 📋 Known Limitations (v1.0 Framework Release)
+
+- **`Papers/P5_GeneralRelativity/GR/Schwarzschild.lean`** is schematic: it defines the typed pipeline (metric → Γ → Ricci → Einstein) but uses `True` placeholders rather than explicit component formulas/derivatives. No `sorry` are used; symbolic proofs are scheduled for v1.1.
+- All portal/profile results are fully checked and compositional; the axiom audit shows only `propext` for core algebra and the intended portal axioms.
 
 ## 🔬 Hybrid Development Plan
 

--- a/scripts/SchematicAudit.sh
+++ b/scripts/SchematicAudit.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# SchematicAudit.sh - Ensure True placeholders only appear in whitelisted schematic files
+# This preserves the "no-sorry" bar while allowing schematic scaffolds in specific modules
+
+ALLOW_RE='(GR/(Schwarzschild|EPSCore)|Smoke)\.lean'
+
+echo "Checking for non-schematic True placeholders in Paper 5..."
+
+violations=$(rg -n ":\s*True\s*:=" Papers/P5_GeneralRelativity | \
+  grep -vE "$ALLOW_RE" || true)
+
+if [ -n "$violations" ]; then
+  echo "❌ Non-schematic True placeholders found:"
+  echo "$violations"
+  echo ""
+  echo "True placeholders should only appear in explicitly whitelisted schematic files:"
+  echo "  - Papers/P5_GeneralRelativity/GR/Schwarzschild.lean"
+  echo "  - Papers/P5_GeneralRelativity/GR/EPSCore.lean"
+  exit 1
+fi
+
+echo "✅ Schematic placeholders restricted to whitelisted files."


### PR DESCRIPTION
## Summary
Clarify that the Schwarzschild module is a schematic scaffold with `True` placeholders, not a complete symbolic verification.

## Changes
- Update LaTeX to explicitly state Schwarzschild uses `True` placeholders for proof obligations
- Add clarification that 'no-sorry' means closed proofs, not all computations completed
- Add Known Limitations section to README documenting schematic modules
- Create `SchematicAudit.sh` script to enforce placeholder restrictions

## Context
This ensures the v1.0 release accurately represents what has been delivered:
- ✅ Complete AxCal framework with portal→profile mapping
- ✅ Composition laws and axiom audit infrastructure  
- ✅ Typed scaffold for Schwarzschild pipeline
- ⏳ Concrete symbolic computations deferred to v1.1

The release can ship as a **framework release** with clear documentation about what is schematic vs fully implemented.