### PR TITLE
fix(P6): Apply hygiene patches and fix RS proof factor

### DIFF
--- a/Papers/P6_Heisenberg/Paper6_HeisenbergAxCal.tex
+++ b/Papers/P6_Heisenberg/Paper6_HeisenbergAxCal.tex
@@ -45,6 +45,10 @@
 \newcommand{\lean}[1]{\texttt{#1}}
 \newcommand{\leanok}{\text{\tiny [✓ Lean Verified]}}
 
+% Status badges
+\newcommand{\leanaxiom}{\text{\tiny [Axiom]}}
+\newcommand{\leanpartial}{\text{\tiny [Lean-partial]}}
+
 % Physics/macros
 \newcommand{\R}{\mathbb{R}}
 \newcommand{\C}{\mathbb{C}}
@@ -145,6 +149,15 @@ Section~\ref{sec:measurement-DC} analyzes measurement uncertainty and its relian
 Section~\ref{sec:implications} discusses the foundational implications of this geometric/dynamical separation.
 Technical details on the Lean formalization appear in Appendix~\ref{sec:engineering}.
 
+\paragraph{Scope \& Dependencies (CRM hygiene).}
+Unless stated otherwise, our base theory is \(\BISH\). AxCal heights are reported
+relative to the axes \((\WLPO,\FT,\DCw)\); in this paper the only nonzero axis is
+\(\DCw\) on the measurement track. All preparation‑uncertainty results (RS and
+Schrödinger) are fully constructive (height \(\langle\mathbf{0},\mathbf{0},\mathbf{0}\rangle\)).
+Measurement‑uncertainty results are stated conditionally on a foundation token
+\([{\mathrm{Has}\,\DCw}]\,\) and calibrated at \(\le \langle\mathbf{0},\mathbf{0},\boldsymbol{\omega}\rangle\) with the
+\(\DCw\) component at \(\mathbf{1}\).
+
 % ===========================================================
 \section{Background and Related Work}
 \label{sec:related}
@@ -214,13 +227,21 @@ Set $z := \ip{\Delta A\psi}{\Delta B\psi}$. The bridge lemma \lean{comm\_expect\
 \]
 Therefore $\abssq{\E{\comm{A}{B}}_\psi} = \abssq{z - \bar{z}}$.
 
-The exact complex identity gives us $\abssq{z - \bar{z}} \leq 4\abssq{z}$, while Cauchy--Schwarz provides
+Taking squares, the exact complex identity yields $\abssq{z - \bar{z}} \le 4\,\abssq{z}$, while Cauchy--Schwarz provides
 \[
 \abssq{z} = \abssq{\ip{\Delta A\psi}{\Delta B\psi}} \leq \norm{\Delta A\psi}^2 \norm{\Delta B\psi}^2.
 \]
 The variance identity \lean{variance\_centered} connects these norms back to the statistical variances: $\norm{\Delta A\psi}^2 = \Var_\psi(A)$ and similarly for $B$.
 
-Chaining these inequalities and multiplying by $4$ completes the proof.
+Chaining these inequalities gives
+\(
+\abssq{\E{\comm{A}{B}}_\psi}
+=\abssq{z-\bar z}
+\le 4\,\abssq{z}
+\le 4\,\|\Delta A\psi\|^2 \|\Delta B\psi\|^2
+=4\,\Var_\psi(A)\,\Var_\psi(B),
+\)
+as claimed.
 \end{proof}
 
 \begin{remark}[Classical form]
@@ -274,14 +295,14 @@ The Lean bridge \lean{acomm\_expect\_as\_sym\_centered} returns the expression $
 The sequential (disturbance) viewpoint models an experiment producing an infinite history of dependent outcomes.
 Let $H_{\mathrm{fin}}$ be the type of finite histories. Define a \emph{serial} relation $R$ by extending a history by one admissible measurement step. Seriality reflects that every measurement yields some outcome.
 
-\begin{theorem}[Serial DC$\omega$ stream]\leanok
+\begin{theorem}[Serial DC$\omega$ stream]\leanaxiom
 \label{thm:dcomega}
 Assume a foundation $F$ with token $[\mathrm{Has}\DCw\,F]$.
 From any seed in a serial relation there exists an infinite $R$-chain. In particular, the history relation above admits an infinite measurement stream.
 \emph{Lean anchors:} \lean{dcω\_stream} (axiom) and \lean{hupM\_stream\_from\_dcω} (derivation, \texttt{HUP/Witnesses.lean}).
 \end{theorem}
 
-\begin{corollary}[Calibration for HUP--M]\leanok
+\begin{corollary}[Calibration for HUP--M]\leanpartial
 \label{cor:HUPM}
 There is a witness family for measurement uncertainty whose AxCal height is bounded by $\DCwonly$.
 \emph{Lean anchor:} \lean{HUP\_M\_W} and its profile certificate in \texttt{HUP/Witnesses.lean}.


### PR DESCRIPTION
## Summary
- Aligns Paper 6 with AxCal hygiene standards
- Fixes mathematical error in Robertson-Schrödinger proof
- Corrects Lean status badges for accuracy

## Changes

### 1. Status Badges
Added `\leanaxiom` and `\leanpartial` badges to match Papers 3A/3B/4 conventions.

### 2. Scope & Dependencies Section
Added CRM hygiene paragraph clarifying:
- Base theory is BISH
- Heights relative to (WLPO, FT, DCω) axes
- Only DCω is nonzero (on measurement track)
- Preparation results are fully constructive (0,0,0)
- Measurement results use DCω token at height ≤(0,0,ω)

### 3. Fixed RS Proof (Critical Math Fix)
**The Problem:** The proof was multiplying by 4 twice:
- Once from the identity |z - z̄|² ≤ 4|z|²
- Again at the end "multiplying by 4"

**The Fix:** Removed redundant multiplication and showed the complete chain:
```
|⟨[A,B]⟩|² = |z - z̄|² ≤ 4|z|² ≤ 4‖ΔAψ‖²‖ΔBψ‖² = 4 Var(A) Var(B)
```

### 4. Badge Corrections
- **Theorem (DCω stream):** Changed from `\leanok` to `\leanaxiom` (uses axiomatized eliminator)
- **Corollary (HUP-M):** Changed from `\leanok` to `\leanpartial` (derived relative to token)

## Test plan
- [x] LaTeX compiles without errors
- [x] Mathematical proof now correct (single factor of 4)
- [x] Status badges accurately reflect Lean formalization level

🤖 Generated with [Claude Code](https://claude.ai/code)