### PR TITLE
maint: Paper 5 v1.0.1 maintenance release

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -7,9 +7,9 @@ authors:
   orcid: "https://orcid.org/0000-0000-0000-0000"
   affiliation: "AICardiologist"
 title: "Foundation Relativity: Axiom Calibration Framework"
-version: v0.4.0
+version: "1.0.1"
 doi: 10.5281/zenodo.17054050
-date-released: 2025-09-03
+date-released: 2025-09-15
 url: "https://github.com/AICardiologist/FoundationRelativity"
 repository-code: "https://github.com/AICardiologist/FoundationRelativity"
 abstract: >-

--- a/Papers/P5_GeneralRelativity/AxCalCore/ProfileLUB.lean
+++ b/Papers/P5_GeneralRelativity/AxCalCore/ProfileLUB.lean
@@ -48,7 +48,7 @@ theorem maxAP_assoc (p q r : AxisProfile) :
 theorem maxAP_idem (p : AxisProfile) : maxAP p p = p := by
   cases p <;> simp [maxAP, maxH_idem]
 
-theorem maxH_if_one_zero (a b : Bool) :
+@[simp] theorem maxH_if_one_zero (a b : Bool) :
   maxH (if a then Height.one else Height.zero)
        (if b then Height.one else Height.zero)
     = (if a || b then Height.one else Height.zero) := by

--- a/Papers/P5_GeneralRelativity/GR/Witnesses.lean
+++ b/Papers/P5_GeneralRelativity/GR/Witnesses.lean
@@ -6,6 +6,13 @@ Witness families for the five GR calibration targets
 import Papers.P5_GeneralRelativity.GR.Portals
 import Papers.P5_GeneralRelativity.GR.Interfaces
 
+/-!
+  This module declares schematic witness-family signatures used by the AxCal ledger.
+  Many binders are intentionally unused in this abstract layer. We silence the
+  `unusedVariables` linter locally to keep CI noise-free.
+-/
+set_option linter.unusedVariables false
+
 namespace Papers.P5_GeneralRelativity
 open Papers.P5_GeneralRelativity
 

--- a/README.md
+++ b/README.md
@@ -93,6 +93,11 @@ A Lean 4 formalization project that calibrates the exact logical strength requir
    - GR pin (Σ₀^GR): Manifolds, tensors, Einstein tensor
    - Three orthogonal axes: Choice (AC/DCω/ACω), Compactness/Kinematics (FT/WKL₀), Logic/Computability (WLPO/LEM/MP)
    - Targets G1-G5: Explicit solutions → Computable GR evolution
+   - Portal→Profile mappings (v1.0.1):
+     - Zorn → (1,0,0) on Choice axis
+     - Serial-Chain (DCω) → (1,0,0) on Choice axis
+     - Limit-Curve → (0,1,0) on Compactness axis
+     - Reductio → (0,0,1) on Logic axis
    - Complete Lean 4 formalization with portal theorems and height certificates
    - CI/CD pipeline with automated PDF generation and axiom auditing
 


### PR DESCRIPTION
## Summary
- DCω axis alignment patches (already merged)
- Linter warning cleanup
- Documentation updates for v1.0.1 release

## Changes in this PR
- **Witnesses.lean**: Silence intentional unused variable warnings
- **ProfileLUB.lean**: Add @[simp] attribute to maxH_if_one_zero
- **README.md**: Document Portal→Profile mappings
- **CITATION.cff**: Bump version to 1.0.1

## Test plan
- [x] Build completes successfully
- [x] Pre-commit checks pass
- [x] Portal mappings documented

This prepares the v1.0.1 maintenance release tag.

🤖 Generated with [Claude Code](https://claude.ai/code)